### PR TITLE
Fix spectate button not working

### DIFF
--- a/resource/ui/teammenu.res
+++ b/resource/ui/teammenu.res
@@ -867,7 +867,7 @@
 		"textAlignment"	"center"
 		"dulltext"		"0"
 		"brighttext"	"0"
-		"command"		"jointeam spectatearena"
+		"command"		"jointeam spectate"
 		"font"			"SLBoldMediumSmaller"
 		
 		"sound_armed"		"ui/item_info_mouseover.wav"


### PR DESCRIPTION
For some reason the command for spectate button was "jointeam spectatearena" instead of "jointeam spectate"?